### PR TITLE
Added submission form

### DIFF
--- a/source/first_party/analyzers/index.rst
+++ b/source/first_party/analyzers/index.rst
@@ -15,3 +15,9 @@ submit any questions as new issues tagged with "question".
    :caption: Liquid Chromatography
    
    waters_patrol_uplc_report_parser
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Mock Analyzers
+   
+   mock_lc_parser

--- a/source/first_party/analyzers/mock_lc_parser.rst
+++ b/source/first_party/analyzers/mock_lc_parser.rst
@@ -1,0 +1,17 @@
+Mock LC Parser
+==============
+
+Plugin class: Analyzer
+
+Acquisition
+-----------
+
+This plugin is available for download at 
+`<https://github.com/RxnRover/plugin_mock_lc_parser>`_.
+
+Description
+-----------
+
+This plugin generates and parses report files as if they were generated from a 
+liquid chromatograph (LC). The data generated is random and this plugin is only
+meant to be used as a demonstration of a file parser as an analyzer plugin.


### PR DESCRIPTION
Added the submission form for the Mock LC Parser plugin as an example. I tested links present in the submission form and built the documentation on my local machine to verify that my entry appears correctly in the catalog.